### PR TITLE
Update pvp toggle

### DIFF
--- a/config.lua
+++ b/config.lua
@@ -101,7 +101,7 @@ Config.MenuItems = {
                 title = 'Toggle PVP on/off',
                 icon = 'hand-holding-hand',
                 type = 'client',
-                event = 'rsg-pvp:client:pvpToggle',
+                event = 'rsg-essentials:client:pvpToggle',
                 shouldClose = true
             }, 
             {


### PR DESCRIPTION
**Removed Wrong event:**
- Removed `rsg-pvp:client:pvpToggle` since **rsg-pvp** doesn’t exist in **RSG Recipe**.

**Integrated into Essentials:**
- Added `rsg-essentials:client:pvpToggle` to handle PVP toggling.
- Added notifications for PVP state changes.